### PR TITLE
Add PokemonMapWalker

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Please take a moment to read over the [contribution guidelines](https://github.c
 * [Pokemon-Go-Controller](https://github.com/kahopoon/Pokemon-Go-Controller) - Play PokemonGO safely or at unavailable area.
 * [PokemonGoControllerSuite](https://github.com/adin283/PokemonGoControllerSuite) - HTML web application to control PokemonGO.
 * [pokemongo-genymotion](https://github.com/jlobos/pokemongo-genymotion) - Play Pokémon Go from your Genymotion Device.
+* [PokemonMapWalker](https://github.com/wangpy/PokemonMapWalker) - Cocoa app to play PokemonGo by moving on map manually.
 
 ##### Mappers
 


### PR DESCRIPTION
Hello,
I suggest to add PokemonMapWalker which is a project of my friends and me.
It's a manual controller which enable people who can't play PokemonGo realistically (ex. from unavailable area or inconvenient situation) to play the game.
It is not a bot and doesn't contain any automation features.
Please kindly consider adding this project to the list.
Thanks!
