### PR TITLE
Updated link to POGO-UWP because the old one was no longer maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Please take a moment to read over the [contribution guidelines](https://github.c
 
 ##### Windows Phone
 
-* [PoGo-UWP](https://github.com/ST-Apps/PoGo-UWP/releases) - Unofficial Windows 10 Mobile client.
+* [PoGo-UWP](https://github.com/mtaheij/PoGo-UWP/releases) - Unofficial Windows 10 (both Mobile and PC) client.
 * [PoGo](https://github.com/PoGo-Devs/PoGo) - UWP Client for Pokemon Go.
 
 #### Online


### PR DESCRIPTION
The github repository for PoGo-UWP by ST-Apps is no longer maintained.
New link points to a forked repo that is up to date and working!